### PR TITLE
Add root layout for Next.js app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "eaf-viu-v2",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "lucide-react": "^0.378.0",
+    "next": "14.2.3",
+    "react": "^18",
+    "react-dom": "^18",
+    "recharts": "^2.12.7",
+    "tailwind-merge": "^2.3.0",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "eslint": "^8",
+    "eslint-config-next": "14.2.3",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1"
+  }
+}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,0 +1,9 @@
+export const metadata = { title: "My App" };
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hello</h1>;
+}


### PR DESCRIPTION
## Summary
- add root layout component with metadata
- add basic page component and package.json to enable builds

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894f4e2232883328aeaf2e76f7f9ceb