### PR TITLE
Remove duplicate app directory causing layout errors

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,9 +1,0 @@
-export const metadata = { title: "My App" };
-
-export default function RootLayout({ children }) {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  );
-}

--- a/app/page.js
+++ b/app/page.js
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <h1>Hello</h1>;
-}


### PR DESCRIPTION
## Summary
- Remove redundant top-level `app` directory to rely solely on `src/app`
- Ensure Next.js uses the root layout defined in `src/app/layout.js`

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689501a26e608332ac17cd2e2926a1e8